### PR TITLE
fix: add missing imports and env variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
-FROM jinaai/jina:2.0.0rc10
+FROM jinaai/jina:2.0
 
 # install git
-RUN apt-get -y update && apt-get install -y git
+RUN apt-get -y update && apt-get install -y git curl  && apt-get install -y libsndfile-dev
 
 # install requirements before copying the workspace
 COPY requirements.txt /requirements.txt
 RUN pip install -r requirements.txt
 
 # setup the workspace
-COPY . /workspace
+COPY ./ /workspace
 WORKDIR /workspace
 
+RUN ./scripts/download_model.sh
+
+ENV PYTHONPATH=/workspace
 ENTRYPOINT ["jina", "executor", "--uses", "config.yml"]

--- a/config.yml
+++ b/config.yml
@@ -3,4 +3,10 @@ with:
   {}
 metas:
   py_modules:
+    - vggish/mel_features.py
+    - vggish/vggish_input.py
+    - vggish/vggish_params.py
+    - vggish/vggish_postprocess.py
+    - vggish/vggish_slim.py
     - vggish_audio_encoder.py
+

--- a/vggish/vggish_input.py
+++ b/vggish/vggish_input.py
@@ -20,6 +20,10 @@ __license__ = "Apache-2.0"
 
 import resampy
 
+import sys
+import os
+sys.path.append(os.getcwd())
+
 from vggish.vggish_params import *
 from vggish.mel_features import *
 


### PR DESCRIPTION
This PR fixes the code to work with `f = Flow().add(uses='jinahub+docker://VGGishAudioEncoder', timeout_ready=60000)`